### PR TITLE
feat(supermicro): Reset Intrusion Alert if alerting

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ docker run -d -p 0.0.0.0:9096:9096 \
 
 Redfish Exporter is providing generic metrics fetched from Redfish endpoints.
 
+## Example request
+
+```bash
+curl http://localhost:9096/metrics?host=https://<ip>
+```
+
+## Pre Actions
+
+This exporter also allows to handle pre actions before fetching metrics. This can be useful to enable metrics on the server
+or handle specific errors before fetching metrics.
+
+Currently the following actions are supported:
+
+- reset_intrusion_alert - Reset intrusion alert on the server
+
 ### Tested with
 * HPE ILO4
 * HPE ILO5

--- a/config.example.yml
+++ b/config.example.yml
@@ -8,3 +8,7 @@ redfish:
   verifyTls: true
   username: Administrator
   password: toor
+
+# Actions to perform before collecting metrics
+preActions:
+  - reset_intrusion_alert

--- a/pkg/actions/registry.go
+++ b/pkg/actions/registry.go
@@ -1,0 +1,27 @@
+package actions
+
+import (
+	"fmt"
+
+	"github.com/g-portal/redfish_exporter/pkg/api"
+	"github.com/g-portal/redfish_exporter/pkg/config"
+)
+
+const (
+	ResetIntrusionAlert config.Action = "reset_intrusion_alert"
+)
+
+func Execute(action config.Action, client api.Client) error {
+	switch action {
+	case ResetIntrusionAlert:
+		err := client.ResetChassisIntrusion()
+		if err != nil {
+			return fmt.Errorf("error resetting chassis intrusion: %w", err)
+		}
+
+		return nil
+	default:
+		//nolint: err113
+		return fmt.Errorf("unknown action %s", action)
+	}
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -10,6 +10,7 @@ import (
 type Client interface {
 	Connect(host, username, password string, tlsVerify bool) error
 	GetMetrics() (*prometheus.Registry, error)
+	ResetChassisIntrusion() error
 	Disconnect() error
 }
 

--- a/pkg/config/format.go
+++ b/pkg/config/format.go
@@ -1,5 +1,7 @@
 package config
 
+type Action string
+
 type Config struct {
 	Verbose bool `yaml:"verbose"`
 
@@ -13,4 +15,6 @@ type Config struct {
 		// Verify Whether to verify the TLS certificate
 		VerifyTLS bool `yaml:"verifyTls"`
 	} `yaml:"redfish"`
+
+	PreActions []Action `yaml:"preActions"`
 }

--- a/pkg/drivers/redfish/intrusion.go
+++ b/pkg/drivers/redfish/intrusion.go
@@ -1,0 +1,28 @@
+package redfish
+
+import (
+	"fmt"
+
+	"github.com/stmcginnis/gofish/redfish"
+)
+
+func (rf *Redfish) ResetChassisIntrusion() error {
+	chassisCollection, err := rf.client.Service.Chassis()
+	if err != nil {
+		return fmt.Errorf("error getting chassis: %w", err)
+	}
+
+	for _, chassis := range chassisCollection {
+		if chassis.PhysicalSecurity.IntrusionSensor == redfish.HardwareIntrusionIntrusionSensor {
+			if err = chassis.Patch(chassis.ODataID, map[string]interface{}{
+				"PhysicalSecurity": map[string]interface{}{
+					"IntrusionSensor": redfish.NormalIntrusionSensor,
+				},
+			}); err != nil {
+				return fmt.Errorf("error updating chassis: %w", err)
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
In our use case we don't want to have "Critical" system alerts when the intrusion error goes off. In that case we log these one-time on our monitoring tool but directly after this we want to solve this automatically and no longer alert that host.